### PR TITLE
ISA encoding fixes

### DIFF
--- a/ppci/arch/atalla/instructions.py
+++ b/ppci/arch/atalla/instructions.py
@@ -312,8 +312,8 @@ class Jalr(AtallaIInstruction):
         tokens[0][15:23] = self.rs1.num
         return tokens[0].encode()
 
-Halt = make_nop("halt", 0b1111111)
-Nop = make_nop("nop", 0x00000000)
+Halt = make_nop("halt", 0b0110000)
+Nop = make_nop("nop", 0b0101111)
 
 # Because I need dcd so it does not throw errors but I don't think it needs a relocation class and is probably integers only
 def dcd(v):

--- a/ppci/arch/atalla/tokens.py
+++ b/ppci/arch/atalla/tokens.py
@@ -94,16 +94,16 @@ class AtallaMTSToken(Token):
     class Info:
         size = 40
     opcode = bit_range(0, 7)
-    vmd    = bit_range(7, 11)
-    rs1     = bit_range(15, 23)
+    rd     = bit_range(7, 15)
+    vms    = bit_range(15, 19)
 
 
 class AtallaSTMToken(Token):
     class Info:
         size = 40
     opcode = bit_range(0, 7)
-    rd    = bit_range(7, 15)
-    vmd    = bit_range(15, 19)
+    vmd    = bit_range(7, 11)
+    rs1    = bit_range(15, 23)
 
 class AtallaVTSToken(Token):
     class Info:

--- a/ppci/arch/atalla/vector_instructions.py
+++ b/ppci/arch/atalla/vector_instructions.py
@@ -182,19 +182,19 @@ class AtallaMTSInstruction(Instruction):
     isa = isa
 
 def make_stm(mnemonic: str, opcode: int):
-    rd = Operand("rd", AtallaRegister, read=True)
+    rs1 = Operand("rs1", AtallaRegister, read=True)
     vmd = Operand("vmd", AtallaMaskRegister, write=True)
-    syntax = Syntax([mnemonic, " ", vmd, ",", " ", rd])
-    patterns = {"opcode": opcode, "vmd": vmd, "rd": rd}
-    members = {"syntax": syntax, "vmd": vmd, "rd": rd, "patterns": patterns, "opcode": opcode}
+    syntax = Syntax([mnemonic, " ", vmd, ",", " ", rs1])
+    patterns = {"opcode": opcode, "vmd": vmd, "rs1": rs1}
+    members = {"syntax": syntax, "vmd": vmd, "rs1": rs1, "patterns": patterns, "opcode": opcode}
     return type(mnemonic.replace(".", "_"), (AtallaSTMInstruction,), members)
 
 def make_mts(mnemonic: str, opcode: int):
-    rs1 = Operand("rs1", AtallaRegister, write=True)
-    vmd = Operand("vmd", AtallaMaskRegister, read=True)
-    syntax = Syntax([mnemonic, " ", rs1, ",", " ", vmd])
-    patterns = {"opcode": opcode, "rs1": rs1, "vmd": vmd}
-    members = {"syntax": syntax, "rs1": rs1, "vmd": vmd, "patterns": patterns, "opcode": opcode}
+    rd = Operand("rd", AtallaRegister, write=True)
+    vms = Operand("vms", AtallaMaskRegister, read=True)
+    syntax = Syntax([mnemonic, " ", rd, ",", " ", vms])
+    patterns = {"opcode": opcode, "rd": rd, "vms": vms}
+    members = {"syntax": syntax, "rd": rd, "vms": vms, "patterns": patterns, "opcode": opcode}
     return type(mnemonic.replace(".", "_"), (AtallaMTSInstruction,), members)
 
 MvStm = make_stm("mv_stm", 0b1001100)


### PR DESCRIPTION
- Add sac operand (bits [35:40]) to all VV instructions per updated ISA spec
- Fix MTS/STM token field layout swap (rd/rs1 vs vmd/vms positions) per Navya's updated bit spec
- Correct halt opcode to 0b0110000 and nop to 0b0101111